### PR TITLE
agentic: add build/dev/test/review/approve/plan workflows

### DIFF
--- a/.github/workflows/approve.md
+++ b/.github/workflows/approve.md
@@ -1,0 +1,22 @@
+---
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+network: defaults
+safe-outputs:
+  approve-pr:
+    max: 1
+  add-comment:
+    max: 3
+---
+
+# Approve agent
+
+You are an approval agent for a Python project. When a PR has a passing
+CI status and no outstanding review requests, approve it via the approve-pr
+output. If CI failed or review changes were requested, do not approve and comment
+why. Never merge.

--- a/.github/workflows/build.md
+++ b/.github/workflows/build.md
@@ -1,0 +1,24 @@
+---
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, master]
+permissions:
+  contents: read
+  pull-requests: read
+network: defaults
+safe-outputs:
+  create-pull-request:
+    max: 1
+---
+
+# Build agent for Python
+
+You are a build agent. In the current repo, set up and run the build using:
+- Setup: Python 3.11 + pip
+- Build command: `python -m build || pip install -e . || true`
+
+If the build fails, diagnose the error, fix the root cause in source (not by
+disabling checks), and open a pull request titled "build: fix build for Python"
+with the minimal change. Do not push to main directly. Only modify files needed
+for the build to succeed.

--- a/.github/workflows/develop.md
+++ b/.github/workflows/develop.md
@@ -1,0 +1,20 @@
+---
+on:
+  workflow_dispatch:
+  issues:
+    types: [opened]
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+network: defaults
+safe-outputs:
+  create-pull-request:
+    max: 2
+---
+
+# Development agent
+
+You are a development agent for a Python project. When a feature issue
+is opened, implement it in the codebase following the repo's existing patterns.
+Open a pull request that references the issue. Keep changes scoped. Do not merge.

--- a/.github/workflows/plan.md
+++ b/.github/workflows/plan.md
@@ -1,0 +1,19 @@
+---
+on:
+  workflow_dispatch:
+  schedule: weekly on monday
+permissions:
+  contents: read
+  issues: write
+network: defaults
+safe-outputs:
+  create-issue:
+    max: 1
+---
+
+# Planning agent (next build cycle)
+
+You are a planning agent for a Python project. At the start of each
+build cycle, inspect the repo's open issues, recent commits, and TODO markers.
+Open a single planning issue titled "Build cycle plan" listing the
+prioritized next features to build, in order. Do not implement; only plan.

--- a/.github/workflows/pr-review.md
+++ b/.github/workflows/pr-review.md
@@ -1,0 +1,22 @@
+---
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+network: defaults
+safe-outputs:
+  add-review:
+    max: 1
+  add-comment:
+    max: 5
+---
+
+# PR review agent
+
+You are a senior reviewer for a Python project. On each PR, review the
+diff for correctness, security (secret leakage, unsafe API use), and adherence to
+the repo's style. Post an inline review via the review output. Request changes if
+blocking issues exist; otherwise approve. Never merge.

--- a/.github/workflows/test.md
+++ b/.github/workflows/test.md
@@ -1,0 +1,19 @@
+---
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+permissions:
+  contents: read
+  pull-requests: read
+network: defaults
+safe-outputs:
+  create-pull-request:
+    max: 1
+---
+
+# Test agent
+
+You are a test agent for a Python project. Ensure the test command
+`pytest || true` passes. If tests are missing for changed code, add them. If they
+fail, fix the code (not the tests) and open a PR. Do not push to main.


### PR DESCRIPTION
Adds 6 gh aw agentic workflows (build, develop, test, pr-review, approve, plan) tailored to this repo's stack. These enable agentic automation for building, developing, testing, PR review, approval, and planning the next build cycle.